### PR TITLE
Feat : 지출 읽기 목록, 상세, 합계 제외

### DIFF
--- a/src/main/java/com/wanted/fundfolio/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/controller/ExpenditureController.java
@@ -3,7 +3,9 @@ package com.wanted.fundfolio.api.expenditure.controller;
 import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadListResponse;
 import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadRequest;
 import com.wanted.fundfolio.api.expenditure.dto.ExpenditureRequest;
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureResponse;
 import com.wanted.fundfolio.api.expenditure.service.ExpenditureService;
+import com.wanted.fundfolio.domain.expenditure.entity.Expenditure;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,5 +50,12 @@ public class ExpenditureController {
         String username = principal.getName().split(":")[0];
         ExpenditureReadListResponse response = expenditureService.readListAll(username, request);
         return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> read(@PathVariable Long id, Principal principal){
+        String username = principal.getName().split(":")[0];
+        ExpenditureResponse read = expenditureService.read(username, id);
+        return ResponseEntity.ok().body(read);
     }
 }

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/controller/ExpenditureController.java
@@ -1,5 +1,7 @@
 package com.wanted.fundfolio.api.expenditure.controller;
 
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadListResponse;
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadRequest;
 import com.wanted.fundfolio.api.expenditure.dto.ExpenditureRequest;
 import com.wanted.fundfolio.api.expenditure.service.ExpenditureService;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +41,12 @@ public class ExpenditureController {
         String username = principal.getName().split(":")[0];
         expenditureService.excludingTotal(id, username);
         return ResponseEntity.ok().body("합계 제외");
+    }
+
+    @GetMapping("/findAll")
+    public ResponseEntity<?> readListAll(ExpenditureReadRequest request,Principal principal){
+        String username = principal.getName().split(":")[0];
+        ExpenditureReadListResponse response = expenditureService.readListAll(username, request);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/controller/ExpenditureController.java
@@ -33,4 +33,11 @@ public class ExpenditureController {
         expenditureService.delete(id, username);
         return ResponseEntity.ok().body("삭제");
     }
+
+    @PostMapping("/exclude/{id}")
+    public  ResponseEntity<?> excludingTotal(@PathVariable Long id,Principal principal){
+        String username = principal.getName().split(":")[0];
+        expenditureService.excludingTotal(id, username);
+        return ResponseEntity.ok().body("합계 제외");
+    }
 }

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureReadListResponse.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureReadListResponse.java
@@ -1,0 +1,19 @@
+package com.wanted.fundfolio.api.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ExpenditureReadListResponse {
+
+    private List<ExpenditureReadResponse> list;
+    private long amountAll;
+    private long amountByCategory;
+
+    public static ExpenditureReadListResponse of(List<ExpenditureReadResponse> list, long amountAll, long amountByCategory){
+        return new ExpenditureReadListResponse(list,amountAll,amountByCategory);
+    }
+}

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureReadRequest.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureReadRequest.java
@@ -1,0 +1,30 @@
+package com.wanted.fundfolio.api.expenditure.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wanted.fundfolio.domain.category.entity.CategoryType;
+import lombok.Getter;
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+@Getter
+public class ExpenditureReadRequest {
+
+    private long minAmount;
+    private long maxAmount;
+
+    private CategoryType categoryType;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate startDate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate endDate;
+
+    public ExpenditureReadRequest(long minAmount, long maxAmount, CategoryType categoryType, LocalDate startDate, LocalDate endDate) {
+        this.minAmount = minAmount;
+        this.maxAmount = maxAmount;
+        this.categoryType = categoryType;
+        this.startDate = startDate == null ? YearMonth.now().atDay(1) : startDate;
+        this.endDate = endDate == null ? YearMonth.now().atEndOfMonth() : endDate;
+    }
+}

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureReadResponse.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureReadResponse.java
@@ -1,0 +1,22 @@
+package com.wanted.fundfolio.api.expenditure.dto;
+
+import com.wanted.fundfolio.domain.category.entity.CategoryType;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+public class ExpenditureReadResponse {
+
+    private Long ExpenditureId;
+
+    private long amount;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private CategoryType categoryType;
+
+    private boolean excludeTotal;
+}

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureResponse.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/dto/ExpenditureResponse.java
@@ -1,0 +1,29 @@
+package com.wanted.fundfolio.api.expenditure.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.wanted.fundfolio.domain.category.entity.CategoryType;
+import com.wanted.fundfolio.domain.expenditure.entity.Expenditure;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class ExpenditureResponse {
+    private Long amount;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private String content;
+
+    private CategoryType categoryType;
+    private boolean excludeTotal;
+
+    public static ExpenditureResponse of(Expenditure expenditure){
+        return new ExpenditureResponse(expenditure.getAmount(),expenditure.getDate(),expenditure.getContent()
+                ,expenditure.getCategory().getCategoryType(), expenditure.isExcludeTotal());
+    }
+}

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/service/ExpenditureService.java
@@ -1,6 +1,7 @@
 package com.wanted.fundfolio.api.expenditure.service;
 
 import com.wanted.fundfolio.api.category.service.CategoryService;
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadResponse;
 import com.wanted.fundfolio.api.expenditure.dto.ExpenditureRequest;
 import com.wanted.fundfolio.api.user.service.MemberService;
 import com.wanted.fundfolio.domain.category.entity.Category;
@@ -10,8 +11,11 @@ import com.wanted.fundfolio.domain.member.entity.Member;
 import com.wanted.fundfolio.global.exception.ErrorCode;
 import com.wanted.fundfolio.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -62,5 +66,20 @@ public class ExpenditureService {
     public Expenditure findExpenditure(Long id){
         return expenditureRepository.findById(id)
                 .orElseThrow(() -> new ErrorException(ErrorCode.NON_EXISTENT_EXPENDITURE));
+    }
+
+//    public List<ExpenditureReadResponse> readListAll(){
+//
+//        return
+//    }
+
+    @Transactional
+    public void excludingTotal(Long id, String username){
+        Expenditure expenditure = findExpenditure(id);
+        Member member = memberService.findMember(username);
+        if(member != expenditure.getMember()){
+            throw new ErrorException(ErrorCode.NON_EXISTENT_MEMBER);
+        }
+        expenditure.updateExclude();
     }
 }

--- a/src/main/java/com/wanted/fundfolio/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/fundfolio/api/expenditure/service/ExpenditureService.java
@@ -1,10 +1,7 @@
 package com.wanted.fundfolio.api.expenditure.service;
 
 import com.wanted.fundfolio.api.category.service.CategoryService;
-import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadListResponse;
-import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadRequest;
-import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadResponse;
-import com.wanted.fundfolio.api.expenditure.dto.ExpenditureRequest;
+import com.wanted.fundfolio.api.expenditure.dto.*;
 import com.wanted.fundfolio.api.user.service.MemberService;
 import com.wanted.fundfolio.domain.category.entity.Category;
 import com.wanted.fundfolio.domain.expenditure.entity.Expenditure;
@@ -16,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.print.DocFlavor;
 import java.util.List;
 
 @Service
@@ -91,4 +89,12 @@ public class ExpenditureService {
 
     }
 
+    public ExpenditureResponse read(String username, Long id ){
+        Member member = memberService.findMember(username);
+        Expenditure expenditure = findExpenditure(id);
+        if (member != expenditure.getMember()) {
+            throw new ErrorException(ErrorCode.NON_EXISTENT_MEMBER);
+        }
+        return ExpenditureResponse.of(expenditure);
+    }
 }

--- a/src/main/java/com/wanted/fundfolio/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/fundfolio/domain/expenditure/entity/Expenditure.java
@@ -8,7 +8,6 @@ import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @AllArgsConstructor
@@ -37,6 +36,14 @@ public class Expenditure {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "Member_id")
     private Member member;
+
+    @Column
+    @Builder.Default
+    private boolean excludeTotal = true;
+
+    public void updateExclude(){
+        this.excludeTotal = false;
+    }
 
     public void update(ExpenditureRequest request,Category category){
         this.amount = request.getAmount();

--- a/src/main/java/com/wanted/fundfolio/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/fundfolio/domain/expenditure/entity/Expenditure.java
@@ -20,7 +20,7 @@ public class Expenditure {
     private Long id;
 
     @Column
-    private Long amount;
+    private long amount;
 
     @Column
     @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/com/wanted/fundfolio/domain/expenditure/repo/ExpenditureRepository.java
+++ b/src/main/java/com/wanted/fundfolio/domain/expenditure/repo/ExpenditureRepository.java
@@ -4,5 +4,5 @@ package com.wanted.fundfolio.domain.expenditure.repo;
 import com.wanted.fundfolio.domain.expenditure.entity.Expenditure;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ExpenditureRepository extends JpaRepository<Expenditure,Long> {
+public interface ExpenditureRepository extends JpaRepository<Expenditure,Long>,ExpenditureRepositoryCustom {
 }

--- a/src/main/java/com/wanted/fundfolio/domain/expenditure/repo/ExpenditureRepositoryCustom.java
+++ b/src/main/java/com/wanted/fundfolio/domain/expenditure/repo/ExpenditureRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.wanted.fundfolio.domain.expenditure.repo;
+
+
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadRequest;
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadResponse;
+import com.wanted.fundfolio.domain.category.entity.Category;
+import com.wanted.fundfolio.domain.category.entity.CategoryType;
+import com.wanted.fundfolio.domain.member.entity.Member;
+
+import java.util.List;
+
+public interface ExpenditureRepositoryCustom {
+    List<ExpenditureReadResponse> findList(ExpenditureReadRequest request, Member member, CategoryType categoryType);
+    Long findAmountAll(Member member);
+    Long findAmountByCategory(Category category,Member member);
+}

--- a/src/main/java/com/wanted/fundfolio/domain/expenditure/repo/ExpenditureRepositoryCustomImpl.java
+++ b/src/main/java/com/wanted/fundfolio/domain/expenditure/repo/ExpenditureRepositoryCustomImpl.java
@@ -1,0 +1,60 @@
+package com.wanted.fundfolio.domain.expenditure.repo;
+
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadRequest;
+import com.wanted.fundfolio.api.expenditure.dto.ExpenditureReadResponse;
+import com.wanted.fundfolio.domain.category.entity.Category;
+import com.wanted.fundfolio.domain.category.entity.CategoryType;
+import com.wanted.fundfolio.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.wanted.fundfolio.domain.category.entity.QCategory.category;
+import static com.wanted.fundfolio.domain.expenditure.entity.QExpenditure.expenditure;
+
+@Repository
+@RequiredArgsConstructor
+public class ExpenditureRepositoryCustomImpl implements ExpenditureRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ExpenditureReadResponse> findList(ExpenditureReadRequest request, Member member, CategoryType categoryType){
+        return jpaQueryFactory
+                .select(Projections.fields(ExpenditureReadResponse.class,expenditure.id.as("ExpenditureId")
+                        ,expenditure.amount,expenditure.date,category.categoryType.as("categoryType"),expenditure.excludeTotal))
+                .from(expenditure)
+                .where(expenditure.date.between(request.getStartDate(),request.getEndDate()),
+                        category.categoryType.eq(categoryType),
+                        expenditure.amount.between(request.getMinAmount(), request.getMaxAmount()),
+                        expenditure.member.eq(member))
+                .leftJoin(category)
+                .on(expenditure.category.eq(category))
+                .fetch();
+    }
+
+    @Override
+    public Long findAmountAll(Member member){
+        return jpaQueryFactory
+                .select(expenditure.amount.sum())
+                .from(expenditure)
+                .where(
+                        expenditure.member.eq(member),
+                        expenditure.excludeTotal)
+                .fetchOne();
+    }
+
+    @Override
+    public Long findAmountByCategory(Category category,Member member){
+        return jpaQueryFactory
+                .select(expenditure.amount.sum())
+                .from(expenditure)
+                .where(expenditure.category.eq(category),
+                        expenditure.excludeTotal,
+                        expenditure.member.eq(member))
+                .fetchOne();
+    }
+}


### PR DESCRIPTION
## ✔️ 작업 내용
- 지출 읽기 목록, 상세, 합계 제외 api 로직 구현
## ✏️ 작업 설명
- 967d863f14b5cefdde706c5c9b4054334fe9f852 : 읽기 상세 api 로직 구현
- d9679591415edb5e6ad9a2953a0db44f8b301738 : 읽기 목록 api 로직
- b60e5b337c5980734a1ac955c5788df5d62f7522 : 합계 제외 api 로직
## 📃 통합 테스트
-
## 📃 수동 테스트
![image](https://github.com/myoungjinseo/FundFolio/assets/80959635/9f01ee18-a016-4a01-80a5-9c026f1d0bbd)
![image](https://github.com/myoungjinseo/FundFolio/assets/80959635/bc36a649-1d4a-4c5e-b638-410d87efa856)
![image](https://github.com/myoungjinseo/FundFolio/assets/80959635/e7e95ae5-f296-4ce7-bb2a-64175667bfca)


